### PR TITLE
Add the recipes to undye canvas signs of Farmer's Delight Mod

### DIFF
--- a/data/createplus/recipes/farmersdelight/splashing/canvas_sign.json
+++ b/data/createplus/recipes/farmersdelight/splashing/canvas_sign.json
@@ -1,0 +1,13 @@
+{
+  "type": "create:splashing",
+  "ingredients": [
+    {
+      "tag": "farmersdelight:dyed_canvas_sign"
+    }
+  ],
+  "results": [
+    {
+      "item": "farmersdelight:canvas_sign"
+    }
+  ]
+}

--- a/data/farmersdelight/tags/items/dyed_canvas_sign.json
+++ b/data/farmersdelight/tags/items/dyed_canvas_sign.json
@@ -1,0 +1,21 @@
+{
+  "replace": false,
+  "values": [
+    "farmersdelight:red_canvas_sign",
+    "farmersdelight:orange_canvas_sign",
+    "farmersdelight:yellow_canvas_sign",
+    "farmersdelight:green_canvas_sign",
+    "farmersdelight:lime_canvas_sign",
+    "farmersdelight:blue_canvas_sign",
+    "farmersdelight:light_blue_canvas_sign",
+    "farmersdelight:cyan_canvas_sign",
+    "farmersdelight:magenta_canvas_sign",
+    "farmersdelight:purple_canvas_sign",
+    "farmersdelight:pink_canvas_sign",
+    "farmersdelight:white_canvas_sign",
+    "farmersdelight:gray_canvas_sign",
+    "farmersdelight:light_gray_canvas_sign",
+    "farmersdelight:black_canvas_sign",
+    "farmersdelight:brown_canvas_sign"
+  ]
+}


### PR DESCRIPTION
This PR added the recipes to undye canvas signs of Farmer's Delight Mod.

本PR添加了为农夫乐事的 粗布告示牌 洗掉颜色的配方。本配方使用了机械动力模组的批量洗涤方法。